### PR TITLE
chore: add pre compiled benchmarks

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -10,6 +10,11 @@ fn simple_match(c: &mut Criterion) {
     b.iter(|| assert!(glob::Pattern::new(GLOB).unwrap().matches(PATH)))
   });
 
+  group.bench_function("glob-pre-compiled", |b| {
+    let matcher = glob::Pattern::new(GLOB).unwrap();
+    b.iter(|| assert!(matcher.matches(PATH)))
+  });
+
   group.bench_function("globset", |b| {
     b.iter(|| {
       assert!(globset::Glob::new(GLOB)
@@ -17,6 +22,11 @@ fn simple_match(c: &mut Criterion) {
         .compile_matcher()
         .is_match(PATH));
     })
+  });
+
+  group.bench_function("globset-pre-compiled", |b| {
+    let matcher = globset::Glob::new(GLOB).unwrap().compile_matcher();
+    b.iter(|| assert!(matcher.is_match(PATH)))
   });
 
   group.bench_function("glob-match", |b| {
@@ -43,6 +53,11 @@ fn brace_expansion(c: &mut Criterion) {
         .compile_matcher()
         .is_match(PATH));
     })
+  });
+
+  group.bench_function("globset-pre-compiled", |b| {
+    let matcher = globset::Glob::new(GLOB).unwrap().compile_matcher();
+    b.iter(|| assert!(matcher.is_match(PATH)))
   });
 
   group.bench_function("glob-match", |b| {


### PR DESCRIPTION
Adds benchmarks which use a pre-compiled data structure, comparing `globset`'s Regex construction is not quite fair, since in a usual usecase you would construct once and cache.

Re-Using the `globset::Glob` makes matching much faster (also has a positive effect on `fast_glob`):

```
simple_match/glob       time:   [315.45 ns 316.19 ns 316.88 ns]
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

simple_match/glob-pre-compiled
                        time:   [106.59 ns 107.32 ns 108.28 ns]
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe

simple_match/globset    time:   [16.032 µs 16.117 µs 16.222 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  6 (6.00%) high severe

simple_match/globset-pre-compiled
                        time:   [45.518 ns 45.680 ns 45.937 ns]
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

simple_match/glob-match time:   [204.14 ns 204.22 ns 204.31 ns]
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

simple_match/fast-glob  time:   [82.947 ns 83.165 ns 83.382 ns]
```