### PR TITLE
fix: resolve input type inconsistency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ struct Wildcard {
 
 type BraceStack = ArrayVec<(u32, u32), 10>;
 
-pub fn glob_match<T: AsRef<[u8]>>(glob: T, path: T) -> bool {
+pub fn glob_match(glob: impl AsRef<[u8]>, path: impl AsRef<[u8]>) -> bool {
   let glob = glob.as_ref();
   let path = path.as_ref();
 

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -5,6 +5,15 @@ mod tests {
   use super::*;
 
   #[test]
+  fn generic_input() {
+    assert!(glob_match("**/*", "foo"));
+    assert!(glob_match("**/*".to_string(), "foo"));
+    assert!(glob_match(&"**/*".to_string(), "foo"));
+    assert!(glob_match("**/*".to_string(), "foo".to_string()));
+    assert!(glob_match(&"**/*".to_string(), &"foo".to_string()));
+  }
+
+  #[test]
   fn webpack() {
     // Match everything
     assert!(glob_match("**/*", "foo"));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,6 +11,10 @@ mod tests {
     assert!(glob_match(&"**/*".to_string(), "foo"));
     assert!(glob_match("**/*".to_string(), "foo".to_string()));
     assert!(glob_match(&"**/*".to_string(), &"foo".to_string()));
+
+    assert!(glob_match("**/*".as_bytes(), "foo"));
+    assert!(glob_match("**/*".as_bytes(), "foo".as_bytes()));
+    assert!(glob_match("**/*".as_bytes(), "foo".to_string()));
   }
 
   #[test]


### PR DESCRIPTION
              This is a backwards-incompatible change. Previously, `(&String, &str)` was accepted (via implicit deref coercion from `&String` to `&str`), but now it’s rejected because using the same type parameter `T` twice forces the second argument to be `&String` as well.

_Originally posted by @andersk in https://github.com/shulaoda/fast-glob/pull/7#discussion_r1898189621_
            