### PR TITLE
chore: release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1](https://github.com/oxc-project/fast-glob/compare/v1.0.0...v1.0.1) - 2026-03-03
+
+### Fixed
+
+- treat malformed brace patterns as invalid ([#100](https://github.com/oxc-project/fast-glob/pull/100))
+- avoid panic on deep brace nesting ([#99](https://github.com/oxc-project/fast-glob/pull/99))
+- map `\a` escape sequence to BEL character (`\x07`) ([#98](https://github.com/oxc-project/fast-glob/pull/98))
+
+### Other
+
+- update crate docs repository link ([#101](https://github.com/oxc-project/fast-glob/pull/101))
+- keep \a escaped as literal a
+- *(deps)* lock file maintenance ([#60](https://github.com/oxc-project/fast-glob/pull/60))
+- *(deps)* lock file maintenance ([#51](https://github.com/oxc-project/fast-glob/pull/51))
+
 ## [1.0.0](https://github.com/oxc-project/fast-glob/compare/v0.4.5...v1.0.0) - 2025-07-27
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fast-glob"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrayvec",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-glob"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION



## 🤖 New release

* `fast-glob`: 1.0.0 -> 1.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.1](https://github.com/oxc-project/fast-glob/compare/v1.0.0...v1.0.1) - 2026-03-03

### Fixed

- treat malformed brace patterns as invalid ([#100](https://github.com/oxc-project/fast-glob/pull/100))
- avoid panic on deep brace nesting ([#99](https://github.com/oxc-project/fast-glob/pull/99))
- map `\a` escape sequence to BEL character (`\x07`) ([#98](https://github.com/oxc-project/fast-glob/pull/98))

### Other

- update crate docs repository link ([#101](https://github.com/oxc-project/fast-glob/pull/101))
- keep \a escaped as literal a
- *(deps)* lock file maintenance ([#60](https://github.com/oxc-project/fast-glob/pull/60))
- *(deps)* lock file maintenance ([#51](https://github.com/oxc-project/fast-glob/pull/51))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).