### PR TITLE
fix: map `\a` escape sequence to BEL character (`\x07`)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ fn unescape(c: &mut u8, glob: &[u8], state: &mut State) -> bool {
             return false;
         }
         *c = match glob[state.glob_index] {
-            b'a' => b'\x61',
+            b'a' => b'\x07',
             b'b' => b'\x08',
             b'n' => b'\n',
             b'r' => b'\r',

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -304,11 +304,11 @@ mod tests {
         assert!(!glob_match("\\a*", "**"));
         assert!(!glob_match("\\a*", "\\*"));
 
-        assert!(glob_match("\\a*", "a"));
+        assert!(!glob_match("\\a*", "a"));
         assert!(!glob_match("\\a*", "a/*"));
-        assert!(glob_match("\\a*", "abc"));
-        assert!(glob_match("\\a*", "abd"));
-        assert!(glob_match("\\a*", "abe"));
+        assert!(!glob_match("\\a*", "abc"));
+        assert!(!glob_match("\\a*", "abd"));
+        assert!(!glob_match("\\a*", "abe"));
         assert!(!glob_match("\\a*", "b"));
         assert!(!glob_match("\\a*", "bb"));
         assert!(!glob_match("\\a*", "bcd"));


### PR DESCRIPTION
## Summary

- Fix `\a` escape sequence mapping from `\x61` (literal `a`) to `\x07` (BEL character), consistent with C-style escape semantics
- Update tests to reflect the corrected behavior

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)