### PR TITLE
fix: avoid panic on deep brace nesting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,10 +184,7 @@ impl State {
         brace_stack: &mut BraceStack,
     ) -> bool {
         // Gracefully reject brace expansions deeper than BraceStack capacity.
-        if brace_stack
-            .try_push((open_brace_index as u32, branch_index as u32))
-            .is_err()
-        {
+        if brace_stack.try_push((open_brace_index as u32, branch_index as u32)).is_err() {
             return false;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,13 @@ impl State {
         branch_index: usize,
         brace_stack: &mut BraceStack,
     ) -> bool {
-        brace_stack.push((open_brace_index as u32, branch_index as u32));
+        // Gracefully reject brace expansions deeper than BraceStack capacity.
+        if brace_stack
+            .try_push((open_brace_index as u32, branch_index as u32))
+            .is_err()
+        {
+            return false;
+        }
 
         let mut branch_state = self.clone();
         branch_state.glob_index = branch_index;


### PR DESCRIPTION
## Summary
- guard brace branch stack insertion with `try_push`
- return `false` when brace nesting exceeds `BraceStack` capacity
- prevent runtime panic on deeply nested brace patterns

## Why
`brace_stack.push(...)` could panic for input with nesting depth > 10. This change makes matching fail gracefully instead of panicking.

## Testing
- `cargo test -q`
- manual repro with 11-level nested braces now returns `false` instead of panicking