### PR TITLE
docs: update crate docs repository link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! For detailed usage and API reference, refer to the specific function and struct documentation.
 //!
-//! For any issues or contributions, please visit the [GitHub repository](https://github.com/shulaoda/fast-glob).
+//! For any issues or contributions, please visit the [GitHub repository](https://github.com/oxc-project/fast-glob).
 
 /**
  * The following code is modified based on


### PR DESCRIPTION
## Summary
- update crate-level docs repository URL to the current org/repo

## Why
The doc comment pointed to `shulaoda/fast-glob`, but the active repository is `oxc-project/fast-glob`.

## Testing
- `cargo test -q`
