### PR TITLE
ci: replace OXC_BOT_PAT with GitHub App tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: oxc-project/release-plz@e2b12f55ad64a22af8e93634b94439c42913afca # v1.0.6
         with:
-          PAT: ${{ secrets.OXC_BOT_PAT }}
+          PAT: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3
         id: app-token
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - uses: oxc-project/release-plz@e2b12f55ad64a22af8e93634b94439c42913afca # v1.0.6


### PR DESCRIPTION
## Summary
- replace `OXC_BOT_PAT` workflow usage with `actions/create-github-app-token`
- use `APP_ID` and `APP_PRIVATE_KEY` to mint per-job GitHub App installation tokens
- keep existing workflow behavior for PR creation, release flows, comments, dispatches, and checkout-backed pushes
