### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/oxc-project/fast-glob/compare/v1.0.1...v1.1.0) - 2026-07-21
+
+### Added
+
+- add `validate` API for reporting invalid patterns ([#153](https://github.com/oxc-project/fast-glob/pull/153))
+
+### Other
+
+- update sponsor section ([#151](https://github.com/oxc-project/fast-glob/pull/151))
+- mention glob-match fork ([#148](https://github.com/oxc-project/fast-glob/pull/148))
+- normalize README sponsor section ([#143](https://github.com/oxc-project/fast-glob/pull/143))
+- *(deps)* update dependency rust to v1.95.0 ([#112](https://github.com/oxc-project/fast-glob/pull/112))
+
 ### Added
 
 - `validate` function and `Error` type to reject invalid patterns (unclosed `{` or `[`, trailing `\`, too-deep brace nesting) with a descriptive error

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "fast-glob"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "arrayvec",
  "criterion2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fast-glob"
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 license = "MIT"
 


### PR DESCRIPTION



## 🤖 New release

* `fast-glob`: 1.0.1 -> 1.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/oxc-project/fast-glob/compare/v1.0.1...v1.1.0) - 2026-07-21

### Added

- add `validate` API for reporting invalid patterns ([#153](https://github.com/oxc-project/fast-glob/pull/153))

### Other

- update sponsor section ([#151](https://github.com/oxc-project/fast-glob/pull/151))
- mention glob-match fork ([#148](https://github.com/oxc-project/fast-glob/pull/148))
- normalize README sponsor section ([#143](https://github.com/oxc-project/fast-glob/pull/143))
- *(deps)* update dependency rust to v1.95.0 ([#112](https://github.com/oxc-project/fast-glob/pull/112))

### Added

- `validate` function and `Error` type to reject invalid patterns (unclosed `{` or `[`, trailing `\`, too-deep brace nesting) with a descriptive error

### Fixed

- treat invalid patterns as non-matching under `!` negation, so negated globs like `!src/[abpp.js` no longer match everything
- interpret character classes consistently between brace-branch scanning and matching (e.g. a `,` or `}` inside `[...]` inside braces is a class member, not a branch separator)
- document that the result of `glob_match` for an invalid pattern is unspecified
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).