### PR TITLE
chore: update license copyright holder

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025-present Contributors
+Copyright (c) 2025-present VoidZero Inc. & Contributors
 Copyright (c) 2024 shulaoda
 Copyright (c) 2023 Devon Govett
 


### PR DESCRIPTION
Updates the LICENSE copyright holder to include VoidZero Inc.