### PR TITLE
docs: mention glob-match fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Introduce
 
-A high-performance glob matching crate for Rust based on [`devongovett/glob-match`](https://github.com/devongovett/glob-match).
+A high-performance glob matching crate for Rust forked from [`devongovett/glob-match`](https://github.com/devongovett/glob-match).
 
 **Key Features:**
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //! For any issues or contributions, please visit the [GitHub repository](https://github.com/oxc-project/fast-glob).
 
 /**
- * The following code is modified based on
+ * The following code was originally forked from
  * https://github.com/devongovett/glob-match/blob/d5a6c67/src/lib.rs
  *
  * MIT Licensed


### PR DESCRIPTION
Updates README and source attribution to describe `fast-glob` as forked from `devongovett/glob-match`.