### PR TITLE
feat: add `validate` API for reporting invalid patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `validate` function and `Error` type to reject invalid patterns (unclosed `{` or `[`, trailing `\`, too-deep brace nesting) with a descriptive error
+
+### Fixed
+
+- treat invalid patterns as non-matching under `!` negation, so negated globs like `!src/[abpp.js` no longer match everything
+- interpret character classes consistently between brace-branch scanning and matching (e.g. a `,` or `}` inside `[...]` inside braces is a class member, not a branch separator)
+- document that the result of `glob_match` for an invalid pattern is unspecified
+
 ## [1.0.1](https://github.com/oxc-project/fast-glob/compare/v1.0.0...v1.0.1) - 2026-03-03
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ let path = "some/a/bigger/path/to/the/crazy/needle.txt";
 assert!(glob_match(glob, path));
 ```
 
+## Validation
+
+`glob_match` does not report invalid patterns. For example, an unclosed `{` or `[`, a trailing `\`, or brace expansions nested deeper than 10 levels have an unspecified result (typically no match).
+
+This is a deliberate performance trade-off: `fast-glob` has no compile step and interprets the pattern lazily while matching, so reliably detecting a malformed pattern would require an extra scan on every `glob_match` call.
+
+Validation is instead a separate, one-time step. Use `validate` to reject such patterns with a descriptive error, e.g. when accepting user-written patterns at configuration load time:
+
+```rust
+use fast_glob::{validate, Error, ErrorKind};
+
+assert!(validate("some/**/n*d[k-m]e?txt").is_ok());
+assert_eq!(
+    validate("src/**/*.{js,ts"),
+    Err(Error { kind: ErrorKind::UnclosedBrace, index: 9 })
+);
+```
+
+A pattern accepted by `validate` is guaranteed to be interpreted consistently by `glob_match`.
+
 ## Syntax
 
 | Syntax  | Meaning                                                                                                                                                                                             |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,26 @@
 //! assert!(glob_match(glob, path));
 //! ```
 //!
+//! ## Validation
+//!
+//! [`glob_match`] does not report invalid patterns — an unclosed `{` or `[`,
+//! a trailing `\`, or brace expansions nested deeper than 10 levels have an
+//! unspecified result (typically no match). This is a deliberate performance
+//! trade-off: there is no compile step, and the pattern is interpreted lazily
+//! while matching, so reliably detecting a malformed pattern would require an
+//! extra scan on every call. Validation is instead a separate, one-time step —
+//! use [`validate`] to reject such patterns with a descriptive [`Error`]:
+//!
+//! ```rust
+//! use fast_glob::{validate, Error, ErrorKind};
+//!
+//! assert!(validate("some/**/n*d[k-m]e?txt").is_ok());
+//! assert_eq!(
+//!     validate("src/**/*.{js,ts"),
+//!     Err(Error { kind: ErrorKind::UnclosedBrace, index: 9 })
+//! );
+//! ```
+//!
 //! ## Syntax
 //!
 //! `fast-glob` supports the following glob pattern syntax:
@@ -46,9 +66,12 @@
  * Copyright (c) 2023 Devon Govett
  * https://github.com/devongovett/glob-match/tree/main/LICENSE
  */
+use std::fmt;
 use std::path::is_separator;
 
 use arrayvec::ArrayVec;
+
+const MAX_BRACE_NESTING: usize = 10;
 
 #[derive(Clone, Debug, Default)]
 struct State {
@@ -67,15 +90,141 @@ struct Wildcard {
     brace_depth: u32,
 }
 
-type BraceStack = ArrayVec<(u32, u32), 10>;
+type BraceStack = ArrayVec<(u32, u32), MAX_BRACE_NESTING>;
 
-pub fn glob_match(glob: impl AsRef<[u8]>, path: impl AsRef<[u8]>) -> bool {
-    let glob = glob.as_ref();
-    let path = path.as_ref();
-    glob_match_impl(glob, path)
+/// An error describing why a glob pattern is invalid, returned by [`validate`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Error {
+    /// The kind of invalid construct that was found.
+    pub kind: ErrorKind,
+    /// Byte offset in the pattern of the offending character.
+    pub index: usize,
 }
 
-fn glob_match_impl(glob: &[u8], path: &[u8]) -> bool {
+/// The kind of invalid construct described by an [`Error`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ErrorKind {
+    /// A `{` is never closed by a matching `}`.
+    UnclosedBrace,
+    /// A `[` is never closed by a matching `]`.
+    UnclosedBracket,
+    /// A `\` at the end of the pattern has no character to escape.
+    TrailingBackslash,
+    /// Brace expansions nest deeper than the supported 10 levels.
+    BraceNestingTooDeep,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let index = self.index;
+        match self.kind {
+            ErrorKind::UnclosedBrace => write!(
+                f,
+                "unclosed brace expansion at byte {index}; missing '}}' (to match a literal '{{', escape it as '\\{{' or '[{{]')"
+            ),
+            ErrorKind::UnclosedBracket => write!(
+                f,
+                "unclosed character class at byte {index}; missing ']' (to match a literal '[', escape it as '\\[' or '[[]')"
+            ),
+            ErrorKind::TrailingBackslash => write!(
+                f,
+                "trailing backslash at byte {index} has no character to escape (to match a literal '\\', use '\\\\')"
+            ),
+            ErrorKind::BraceNestingTooDeep => write!(
+                f,
+                "brace expansion at byte {index} nests deeper than the supported {MAX_BRACE_NESTING} levels"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Performs glob pattern matching for `glob` against `path`.
+///
+/// `glob` is expected to be a valid pattern. An invalid pattern — an unclosed
+/// `{` or `[`, a trailing `\`, or brace expansions nested deeper than 10
+/// levels — cannot be reported here and its result is unspecified: typically
+/// it matches nothing, and it never matches through `!` negation, but the
+/// exact behavior may change between releases. Callers accepting user-written
+/// patterns should reject invalid ones up front with [`validate`].
+pub fn glob_match(glob: impl AsRef<[u8]>, path: impl AsRef<[u8]>) -> bool {
+    let (matched, invalid_pattern) = glob_match_internal(glob.as_ref(), path.as_ref());
+    matched && !invalid_pattern
+}
+
+/// Checks that `glob` is a valid pattern.
+///
+/// [`glob_match`] has no way to report an invalid pattern, and its result for
+/// one is unspecified. Call this once when a pattern is first accepted (e.g.
+/// at configuration load time) to reject invalid patterns with an actionable
+/// error instead of silently matching nothing.
+///
+/// A pattern accepted here is never treated as invalid by [`glob_match`], so
+/// its matching behavior is well-defined. For a rejected pattern the result
+/// of [`glob_match`] is unspecified — typically it matches nothing.
+///
+/// # Examples
+///
+/// ```rust
+/// use fast_glob::{validate, Error, ErrorKind};
+///
+/// assert!(validate("some/**/n*d[k-m]e?txt").is_ok());
+/// assert_eq!(
+///     validate("src/**/*.{js,ts"),
+///     Err(Error { kind: ErrorKind::UnclosedBrace, index: 9 })
+/// );
+/// ```
+pub fn validate(glob: impl AsRef<[u8]>) -> Result<(), Error> {
+    let glob = glob.as_ref();
+    let mut index = 0;
+
+    // Leading `!` characters negate the glob and are not part of the pattern.
+    while index < glob.len() && glob[index] == b'!' {
+        index += 1;
+    }
+
+    let mut open_braces = ArrayVec::<usize, MAX_BRACE_NESTING>::new();
+
+    while index < glob.len() {
+        match glob[index] {
+            b'\\' => {
+                if index + 1 >= glob.len() {
+                    return Err(Error { kind: ErrorKind::TrailingBackslash, index });
+                }
+                index += 2;
+            }
+            b'[' => match skip_class(glob, index) {
+                Some(next) => index = next,
+                None => return Err(Error { kind: ErrorKind::UnclosedBracket, index }),
+            },
+            b'{' => {
+                if open_braces.try_push(index).is_err() {
+                    return Err(Error { kind: ErrorKind::BraceNestingTooDeep, index });
+                }
+                index += 1;
+            }
+            // A `}` without a matching `{` is an ordinary character.
+            b'}' => {
+                open_braces.pop();
+                index += 1;
+            }
+            _ => index += 1,
+        }
+    }
+
+    if let Some(&index) = open_braces.first() {
+        return Err(Error { kind: ErrorKind::UnclosedBrace, index });
+    }
+
+    Ok(())
+}
+
+/// Returns the match result (with negation applied) alongside whether the
+/// pattern was detected as invalid, so tests can check the latter against
+/// [`validate`].
+fn glob_match_internal(glob: &[u8], path: &[u8]) -> (bool, bool) {
     let mut state = State::default();
 
     let mut negated = false;
@@ -84,21 +233,51 @@ fn glob_match_impl(glob: &[u8], path: &[u8]) -> bool {
         state.glob_index += 1;
     }
 
-    let mut brace_stack = ArrayVec::<_, 10>::new();
+    let mut brace_stack = BraceStack::new();
     let mut invalid_pattern = false;
     let matched = state.glob_match_from(glob, path, 0, &mut brace_stack, &mut invalid_pattern);
-    if invalid_pattern {
-        return false;
+
+    // A negated glob matches every path its pattern does not — for an invalid
+    // pattern that would be every path, even when the matcher never reaches
+    // the invalid construct (e.g. after an early literal mismatch). Gate the
+    // negation flip on validity instead of relying on lazy detection.
+    if negated && !matched && !invalid_pattern && validate(glob).is_err() {
+        return (false, true);
     }
 
-    negated ^ matched
+    (negated ^ matched, invalid_pattern)
+}
+
+/// Returns the index just past the `]` closing the character class opened by
+/// the `[` at `index`, or `None` if the class is unclosed. Mirrors the class
+/// parsing in `glob_match_from`: an optional `^`/`!` prefix, then the first
+/// character is a literal member (so a leading `]` does not close the class),
+/// and `\` escapes the next character.
+fn skip_class(glob: &[u8], index: usize) -> Option<usize> {
+    let mut index = index + 1;
+    if matches!(glob.get(index), Some(b'^' | b'!')) {
+        index += 1;
+    }
+
+    let mut first = true;
+    loop {
+        match glob.get(index)? {
+            b']' if !first => return Some(index + 1),
+            b'\\' => index += 1,
+            _ => {}
+        }
+        first = false;
+        index += 1;
+    }
 }
 
 #[inline(always)]
-fn unescape(c: &mut u8, glob: &[u8], state: &mut State) -> bool {
+fn unescape(c: &mut u8, glob: &[u8], state: &mut State, invalid_pattern: &mut bool) -> bool {
     if *c == b'\\' {
         state.glob_index += 1;
         if state.glob_index >= glob.len() {
+            // A trailing backslash has nothing to escape.
+            *invalid_pattern = true;
             return false;
         }
         *c = match glob[state.glob_index] {
@@ -158,20 +337,22 @@ impl State {
 
     #[inline(always)]
     fn skip_branch(&mut self, glob: &[u8]) {
-        let mut in_brackets = false;
         let end_brace_depth = self.brace_depth - 1;
         while self.glob_index < glob.len() {
             match glob[self.glob_index] {
-                b'{' if !in_brackets => self.brace_depth += 1,
-                b'}' if !in_brackets => {
+                b'{' => self.brace_depth += 1,
+                b'}' => {
                     self.brace_depth -= 1;
                     if self.brace_depth == end_brace_depth {
                         self.glob_index += 1;
                         return;
                     }
                 }
-                b'[' if !in_brackets => in_brackets = true,
-                b']' => in_brackets = false,
+                b'[' => {
+                    // An unclosed class swallows the rest of the glob.
+                    self.glob_index = skip_class(glob, self.glob_index).unwrap_or(glob.len());
+                    continue;
+                }
                 b'\\' => self.glob_index += 1,
                 _ => (),
             }
@@ -214,7 +395,6 @@ impl State {
         invalid_pattern: &mut bool,
     ) -> bool {
         let mut brace_depth = 0;
-        let mut in_brackets = false;
         let mut has_closing_brace = false;
         let mut matched = false;
 
@@ -224,13 +404,13 @@ impl State {
 
         while self.glob_index < glob.len() {
             match glob[self.glob_index] {
-                b'{' if !in_brackets => {
+                b'{' => {
                     brace_depth += 1;
                     if brace_depth == 1 {
                         branch_index = self.glob_index + 1;
                     }
                 }
-                b'}' if !in_brackets => {
+                b'}' => {
                     brace_depth -= 1;
                     if brace_depth == 0 {
                         has_closing_brace = true;
@@ -260,8 +440,12 @@ impl State {
                     }
                     branch_index = self.glob_index + 1;
                 }
-                b'[' if !in_brackets => in_brackets = true,
-                b']' => in_brackets = false,
+                b'[' => {
+                    // An unclosed class swallows the rest of the glob,
+                    // leaving the brace unclosed as well.
+                    self.glob_index = skip_class(glob, self.glob_index).unwrap_or(glob.len());
+                    continue;
+                }
                 b'\\' => self.glob_index += 1,
                 _ => (),
             }
@@ -354,7 +538,7 @@ impl State {
                             && (first || glob[self.glob_index] != b']')
                         {
                             let mut low = glob[self.glob_index];
-                            if !unescape(&mut low, glob, self) {
+                            if !unescape(&mut low, glob, self, invalid_pattern) {
                                 return false;
                             }
 
@@ -367,7 +551,7 @@ impl State {
                                 self.glob_index += 1;
 
                                 let mut high = glob[self.glob_index];
-                                if !unescape(&mut high, glob, self) {
+                                if !unescape(&mut high, glob, self, invalid_pattern) {
                                     return false;
                                 }
 
@@ -385,6 +569,7 @@ impl State {
                         }
 
                         if self.glob_index >= glob.len() {
+                            *invalid_pattern = true;
                             return false;
                         }
 
@@ -411,7 +596,7 @@ impl State {
                         continue;
                     }
                     mut c if self.path_index < path.len() => {
-                        if !unescape(&mut c, glob, self) {
+                        if !unescape(&mut c, glob, self, invalid_pattern) {
                             return false;
                         }
 
@@ -445,5 +630,58 @@ impl State {
         }
 
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ALPHABET: &[u8] = b"a/*[]{}\\,!-";
+
+    fn for_each_pattern(len: usize, f: &mut impl FnMut(&[u8])) {
+        let mut pattern = vec![0u8; len];
+        for mut n in 0..ALPHABET.len().pow(len as u32) {
+            for slot in &mut pattern {
+                *slot = ALPHABET[n % ALPHABET.len()];
+                n /= ALPHABET.len();
+            }
+            f(&pattern);
+        }
+    }
+
+    /// `validate` and the matcher must agree on what is invalid:
+    /// a pattern `validate` accepts is never flagged invalid by the matcher,
+    /// and an invalid non-negated pattern never matches any path.
+    /// Checked exhaustively over all short patterns built from the special characters.
+    #[test]
+    fn validate_agrees_with_matcher() {
+        const PATHS: &[&str] = &["", "a", "aa", "a/a", "-", ",", "!"];
+
+        for len in 0..=6 {
+            for_each_pattern(len, &mut |pattern| {
+                let valid = validate(pattern).is_ok();
+                for path in PATHS {
+                    let (matched, invalid) = glob_match_internal(pattern, path.as_bytes());
+                    if valid {
+                        assert!(
+                            !invalid,
+                            "matcher flagged {:?} as invalid on path {path:?} but validate accepted it",
+                            String::from_utf8_lossy(pattern),
+                        );
+                    } else if pattern.first() == Some(&b'!') || !pattern.contains(&b'{') {
+                        // A negated invalid pattern never matches (the negation flip is gated on validity),
+                        // and neither does a brace-free one, since every part of its glob is processed directly.
+                        // (A non-negated invalid construct in a non-taken brace branch may go unnoticed,
+                        // that behavior is documented as unspecified.)
+                        assert!(
+                            !(matched && !invalid),
+                            "invalid pattern {:?} matched path {path:?}",
+                            String::from_utf8_lossy(pattern),
+                        );
+                    }
+                }
+            });
+        }
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1715,17 +1715,80 @@ mod tests {
         }
 
         let depth_10 = nested_braces(10, false);
+        assert_eq!(validate(&depth_10), Ok(()));
         assert!(glob_match(&depth_10, "a"));
         assert!(glob_match(&depth_10, "b"));
         assert!(!glob_match(&depth_10, "zzz"));
 
         let depth_11 = nested_braces(11, false);
+        assert_eq!(
+            validate(&depth_11),
+            Err(Error { kind: ErrorKind::BraceNestingTooDeep, index: 10 })
+        );
         assert!(!glob_match(&depth_11, "a"));
         assert!(!glob_match(&depth_11, "zzz"));
 
         let negated_depth_11 = nested_braces(11, true);
         assert!(!glob_match(&negated_depth_11, "a"));
         assert!(!glob_match(&negated_depth_11, "zzz"));
+    }
+
+    #[test]
+    fn validate_patterns() {
+        assert_eq!(validate("some/**/n*d[k-m]e?txt"), Ok(()));
+        assert_eq!(validate("a/{b,c}/d"), Ok(()));
+        assert_eq!(validate("!negated/**"), Ok(()));
+        // Lone closers and commas are ordinary characters.
+        assert_eq!(validate("a}b]c,d"), Ok(()));
+        // A leading `]` is a literal member of a character class.
+        assert_eq!(validate("a[]]b"), Ok(()));
+        // Escaped special characters are ordinary characters.
+        assert_eq!(validate("a\\{b\\[c\\\\d"), Ok(()));
+
+        fn err(kind: ErrorKind, index: usize) -> Result<(), Error> {
+            Err(Error { kind, index })
+        }
+
+        assert_eq!(validate("src/**/*.{js,ts"), err(ErrorKind::UnclosedBrace, 9));
+        assert_eq!(validate("!src/**/*.{js,ts"), err(ErrorKind::UnclosedBrace, 10));
+        assert_eq!(validate("{a,{b,c}"), err(ErrorKind::UnclosedBrace, 0));
+        assert_eq!(validate("src/[abpp.js"), err(ErrorKind::UnclosedBracket, 4));
+        assert_eq!(validate("src/a[]pp.js"), err(ErrorKind::UnclosedBracket, 5));
+        assert_eq!(validate("src/app.js\\"), err(ErrorKind::TrailingBackslash, 10));
+    }
+
+    #[test]
+    fn invalid_patterns_do_not_match_through_negation() {
+        // An invalid pattern is rejected even when the glob is negated,
+        // instead of "matching everything".
+        assert!(!glob_match("src/[abpp.js", "src/app.js"));
+        assert!(!glob_match("!src/[abpp.js", "src/app.js"));
+        assert!(!glob_match("src/app.js\\", "src/app.js"));
+        assert!(!glob_match("!src/app.js\\", "src/app.js"));
+        assert!(!glob_match("src/**/*.{js,ts", "src/app.js"));
+        assert!(!glob_match("!src/**/*.{js,ts", "src/app.js"));
+
+        // Even when the invalid construct is never reached during matching
+        // (mismatch before it), the negation flip is gated on validity.
+        assert!(!glob_match("!src/[abpp.js", "docs/app.js"));
+        assert!(!glob_match("!xyz/*.{js,ts", "src/app.js"));
+        assert!(!glob_match("!abc\\", "xyz"));
+    }
+
+    #[test]
+    fn error_display() {
+        assert_eq!(
+            validate("src/**/*.{js,ts").unwrap_err().to_string(),
+            "unclosed brace expansion at byte 9; missing '}' (to match a literal '{', escape it as '\\{' or '[{]')"
+        );
+        assert_eq!(
+            validate("src/[abpp.js").unwrap_err().to_string(),
+            "unclosed character class at byte 4; missing ']' (to match a literal '[', escape it as '\\[' or '[[]')"
+        );
+        assert_eq!(
+            validate("src/app.js\\").unwrap_err().to_string(),
+            "trailing backslash at byte 10 has no character to escape (to match a literal '\\', use '\\\\')"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`glob_match()` cannot report a malformed pattern (e.g. unclosed `{` or `[`).
(This is a trade-off in favor of performance, though.)

Its result is unspecified and has silently changed between releases (oxc-project/oxc#24612).

Add `validate()` and `Error { kind, index }` so callers can reject such patterns up front.

As we have split the APIs, there is no impact on main performance.

---

Also make the matcher agree with `validate()`:

- flag unclosed classes and trailing backslashes as invalid, and never match an invalid pattern through `!` negation
- unify class scanning via a shared `skip_class`, fixing inconsistent interpretation of `,` and `}` inside `[...]` inside braces

The agreement is enforced by an exhaustive test over all short patterns of the special characters.
