### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,9 @@ wax = "0.6.0"
 [features]
 default = []
 codspeed = ["criterion2/codspeed"]
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.