### PR TITLE
fix: apply the negation offset to the globstar segment check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,7 +235,9 @@ fn glob_match_internal(glob: &[u8], path: &[u8]) -> (bool, bool) {
 
     let mut brace_stack = BraceStack::new();
     let mut invalid_pattern = false;
-    let matched = state.glob_match_from(glob, path, 0, &mut brace_stack, &mut invalid_pattern);
+    let match_start = state.glob_index;
+    let matched =
+        state.glob_match_from(glob, path, match_start, &mut brace_stack, &mut invalid_pattern);
 
     // A negated glob matches every path its pattern does not — for an invalid
     // pattern that would be every path, even when the matcher never reaches

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1387,7 +1387,7 @@ mod tests {
 
         assert!(!glob_match("!.md", ".md"));
         assert!(glob_match("!**/*.md", "a.js"));
-        // assert!(!glob_match("!**/*.md", "b.md"));
+        assert!(!glob_match("!**/*.md", "b.md"));
         assert!(glob_match("!**/*.md", "c.txt"));
         assert!(glob_match("!*.md", "a.js"));
         assert!(!glob_match("!*.md", "b.md"));
@@ -1419,9 +1419,9 @@ mod tests {
         assert!(glob_match("!*.md", "a.js"));
         assert!(glob_match("!*.md", "b.txt"));
         assert!(!glob_match("!*.md", "c.md"));
-        // assert!(!glob_match("!**/a.js", "a/a/a.js"));
-        // assert!(!glob_match("!**/a.js", "a/b/a.js"));
-        // assert!(!glob_match("!**/a.js", "a/c/a.js"));
+        assert!(!glob_match("!**/a.js", "a/a/a.js"));
+        assert!(!glob_match("!**/a.js", "a/b/a.js"));
+        assert!(!glob_match("!**/a.js", "a/c/a.js"));
         assert!(glob_match("!**/a.js", "a/a/b.js"));
         assert!(!glob_match("!a/**/a.js", "a/a/a/a.js"));
         assert!(glob_match("!a/**/a.js", "b/a/b/a.js"));
@@ -1429,7 +1429,7 @@ mod tests {
         assert!(glob_match("!**/*.md", "a/b.js"));
         assert!(glob_match("!**/*.md", "a.js"));
         assert!(!glob_match("!**/*.md", "a/b.md"));
-        // assert!(!glob_match("!**/*.md", "a.md"));
+        assert!(!glob_match("!**/*.md", "a.md"));
         assert!(!glob_match("**/*.md", "a/b.js"));
         assert!(!glob_match("**/*.md", "a.js"));
         assert!(glob_match("**/*.md", "a/b.md"));
@@ -1437,13 +1437,13 @@ mod tests {
         assert!(glob_match("!**/*.md", "a/b.js"));
         assert!(glob_match("!**/*.md", "a.js"));
         assert!(!glob_match("!**/*.md", "a/b.md"));
-        // assert!(!glob_match("!**/*.md", "a.md"));
+        assert!(!glob_match("!**/*.md", "a.md"));
         assert!(glob_match("!*.md", "a/b.js"));
         assert!(glob_match("!*.md", "a.js"));
         assert!(glob_match("!*.md", "a/b.md"));
         assert!(!glob_match("!*.md", "a.md"));
         assert!(glob_match("!**/*.md", "a.js"));
-        // assert!(!glob_match("!**/*.md", "b.md"));
+        assert!(!glob_match("!**/*.md", "b.md"));
         assert!(glob_match("!**/*.md", "c.txt"));
     }
 
@@ -1798,5 +1798,13 @@ mod tests {
         assert!(!glob_match(s, s));
         let s = "**** *{*{??*{??***\u{5} *{*{??*{??***\u{5},\0U\0}]*****\u{1},\0***\0,\0\0}w****,\0U\0}]*****\u{1},\0***\0,\0\0}w*****\u{1}***{}*.*\0\0*\0";
         assert!(!glob_match(s, s));
+    }
+
+    #[test]
+    fn negated_globstar() {
+        assert!(glob_match("**", "a/b"));
+        assert!(!glob_match("!**", "a/b"));
+        assert!(glob_match("!!**", "a/b"));
+        assert!(!glob_match("!!!**", "a/b"));
     }
 }


### PR DESCRIPTION
A leading `**` is treated as a plain `*` when the pattern is negated: on 1.1.0
`glob_match("!**", "a/b")` returns `true`, and `glob_match("!!**", "a/b")`
returns `false`.

`glob_match_impl` consumes the `!` prefix by advancing `state.glob_index` but
still passes `0` as `match_start`, so the globstar check in `glob_match_from` —
`glob_index.saturating_sub(match_start) < 3 || glob[glob_index - 3] == b'/'` —
sees the leading `**` at index 1 and rejects it, falling through to the
single-star path.

Not intended behaviour: `negation()` asserts `glob_match("**/*.md", "a.md")` is
`true` while `glob_match("!**/*.md", "a.md")` also returns `true`.

This also uncomments seven `!**` assertions in `negation()` that the fix makes
pass; I checked their expectations against `picomatch`. The `!(...)` extglob
ones stay commented.